### PR TITLE
depend variable use after defined

### DIFF
--- a/after/plugin/webdevicons/devicons_palette.vim
+++ b/after/plugin/webdevicons/devicons_palette.vim
@@ -1,0 +1,40 @@
+if exists('g:loaded_webdevicons_devicons_palette')
+  finish
+endif
+let g:loaded_webdevicons_devicons_palette = 1
+
+if !get(g:, 'devicons_palette_disable_default_settings')
+  " TODO: Provide more default palette
+  call devicons_palette#settings({
+        \ 'DevIconsPaletteRed': ['rb', 'scala', 'd'],
+        \ 'DevIconsPaletteLightRed': [],
+        \ 'DevIconsPaletteDarkRed': [],
+        \ 'DevIconsPaletteGreen': ['styl', 'twig', 'clj', 'cljc', 'cljs', 'edn', 'vim', 'vue'],
+        \ 'DevIconsPaletteLightGreen': [],
+        \ 'DevIconsPaletteDarkGreen': [],
+        \ 'DevIconsPaletteSeaGreen': [],
+        \ 'DevIconsPaletteBlue': ['css', 'jsx', 'cpp', 'cxx', 'cc', 'cp', 'c', 'sql', 'pl', 'pm', 't', 'fsscript', 'fsx', 'fs', 'fsi', 'psd', 'psb', 'ts', 'tsx'],
+        \ 'DevIconsPaletteLightBlue': [],
+        \ 'DevIconsPaletteDarkBlue': [],
+        \ 'DevIconsPaletteSlateBlue': [],
+        \ 'DevIconsPaletteCyan': ['jpg', 'jpeg', 'bmp', 'png', 'gif', 'ico'],
+        \ 'DevIconsPaletteLightCyan': [],
+        \ 'DevIconsPaletteDarkCyan': [],
+        \ 'DevIconsPaletteMagenta': ['scss', 'php', 'lua', 'java', 'sh', 'sln', 'suo', 'erl', 'ex', 'exs', 'eex', 'jl'],
+        \ 'DevIconsPaletteLightMagenta': [],
+        \ 'DevIconsPaletteDarkMagenta': [],
+        \ 'DevIconsPaletteYellow': ['html', 'md', 'json', 'js', 'mjs', 'py', 'pyc', 'pyo', 'pyd', 'hs', 'lhs', 'ml', 'mli', 'go', 'xul', 'rss', 'rs', 'rlib', 'ai'],
+        \ 'DevIconsPaletteLightYellow': [],
+        \ 'DevIconsPaletteBrown': [],
+        \ 'DevIconsPaletteDarkYellow': [],
+        \ 'DevIconsPaletteGray': [],
+        \ 'DevIconsPaletteLightGray': [],
+        \ 'DevIconsPaletteDarkGray': [],
+        \ 'DevIconsPaletteBlack': [],
+        \ 'DevIconsPaletteWhite': ['conf', 'ini', 'yml', 'yaml', 'bat', 'toml', 'h', 'hpp', 'hxx', 'diff', 'dart', 'pp'],
+        \ 'DevIconsPaletteOrange': [],
+        \ 'DevIconsPalettePurple': [],
+        \ 'DevIconsPaletteViolet': [],
+        \})
+endif
+

--- a/plugin/devicons_palette.vim
+++ b/plugin/devicons_palette.vim
@@ -3,41 +3,6 @@ if exists('g:loaded_devicons_palette')
 endif
 let g:loaded_devicons_palette = 1
 
-if !get(g:, 'devicons_palette_disable_default_settings')
-  " TODO: Provide more default palette
-  call devicons_palette#settings({
-        \ 'DevIconsPaletteRed': ['rb', 'scala', 'd'],
-        \ 'DevIconsPaletteLightRed': [],
-        \ 'DevIconsPaletteDarkRed': [],
-        \ 'DevIconsPaletteGreen': ['styl', 'twig', 'clj', 'cljc', 'cljs', 'edn', 'vim', 'vue'],
-        \ 'DevIconsPaletteLightGreen': [],
-        \ 'DevIconsPaletteDarkGreen': [],
-        \ 'DevIconsPaletteSeaGreen': [],
-        \ 'DevIconsPaletteBlue': ['css', 'jsx', 'cpp', 'cxx', 'cc', 'cp', 'c', 'sql', 'pl', 'pm', 't', 'fsscript', 'fsx', 'fs', 'fsi', 'psd', 'psb', 'ts', 'tsx'],
-        \ 'DevIconsPaletteLightBlue': [],
-        \ 'DevIconsPaletteDarkBlue': [],
-        \ 'DevIconsPaletteSlateBlue': [],
-        \ 'DevIconsPaletteCyan': ['jpg', 'jpeg', 'bmp', 'png', 'gif', 'ico'],
-        \ 'DevIconsPaletteLightCyan': [],
-        \ 'DevIconsPaletteDarkCyan': [],
-        \ 'DevIconsPaletteMagenta': ['scss', 'php', 'lua', 'java', 'sh', 'sln', 'suo', 'erl', 'ex', 'exs', 'eex', 'jl'],
-        \ 'DevIconsPaletteLightMagenta': [],
-        \ 'DevIconsPaletteDarkMagenta': [],
-        \ 'DevIconsPaletteYellow': ['html', 'md', 'json', 'js', 'mjs', 'py', 'pyc', 'pyo', 'pyd', 'hs', 'lhs', 'ml', 'mli', 'go', 'xul', 'rss', 'rs', 'rlib', 'ai'],
-        \ 'DevIconsPaletteLightYellow': [],
-        \ 'DevIconsPaletteBrown': [],
-        \ 'DevIconsPaletteDarkYellow': [],
-        \ 'DevIconsPaletteGray': [],
-        \ 'DevIconsPaletteLightGray': [],
-        \ 'DevIconsPaletteDarkGray': [],
-        \ 'DevIconsPaletteBlack': [],
-        \ 'DevIconsPaletteWhite': ['conf', 'ini', 'yml', 'yaml', 'bat', 'toml', 'h', 'hpp', 'hxx', 'diff', 'dart', 'pp'],
-        \ 'DevIconsPaletteOrange': [],
-        \ 'DevIconsPalettePurple': [],
-        \ 'DevIconsPaletteViolet': [],
-        \})
-endif
-
 if !get(g:, 'devicons_palette_disable')
   augroup devicons_palette
     autocmd! *


### PR DESCRIPTION
webdevicons are defined

- g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols 
- g:WebDevIconsUnicodeDecorateFileNodesExactSymbols 

in `plugin/webdevicons.vim`

This PR is these variable depend function call split to `after/plugin/webdevicons`

## Pros

- Ensures variables are defined
  (Processing order and dependencies become clear)
- User variables configuration affect easy (when defined before load webdevicons)

## Cons

- nothing?
